### PR TITLE
Fix insert statements with missing column names (issue #32)...

### DIFF
--- a/Laan.NHibernate.Appender.Test/ParamBuilderFormatterTest.cs
+++ b/Laan.NHibernate.Appender.Test/ParamBuilderFormatterTest.cs
@@ -20,7 +20,7 @@ command 0:INSERT INTO dbo.[Table] (Version, TypeID, Name, ShortName, Data, UserN
     Version, TypeID, Name, ShortName, Data, UserName, Created, Modified, IsDeleted, 
     Id
     )
-    VALUES (1, '0', 'Reference', NULL, 0, 'auser', '9/03/2012 11:39:50 AM', '9/03/2012 11:39:50 AM', False, 'D4A462AB-DA14-46D2-9118-A00F00C037C6')";
+     VALUES (1, '0', 'Reference', NULL, 0, 'auser', '9/03/2012 11:39:50 AM', '9/03/2012 11:39:50 AM', False, 'D4A462AB-DA14-46D2-9118-A00F00C037C6')";
         [Test]
         public void TestMethod()
         {

--- a/Laan.SQL.Formatter.Test/TestInsertStatementFormatting.cs
+++ b/Laan.SQL.Formatter.Test/TestInsertStatementFormatting.cs
@@ -129,5 +129,26 @@ namespace Laan.Sql.Formatter.Test
 
             Compare(actual, expected);
         }
+
+        [Test]
+        public void Can_Format_More_Columns_Than_MaxOneLineColumnCount_But_Fitting_Up_To_WrapMarginColumn()
+        {
+            // Setup
+            var sut = new FormattingEngine();
+
+            // Exercise
+            var actual = sut.Execute("INSERT INTO Product (Name, Price, ExpiryDate, Aisle, Shelf) VALUES ('Bread', 1.29, NULL, NULL, NULL)");
+
+            // Verify outcome
+            var expected = new[]
+            {
+               "INSERT INTO Product (",
+               "    Name, Price, ExpiryDate, Aisle, Shelf",
+               "    )",
+               "     VALUES ('Bread', 1.29, NULL, NULL, NULL)",
+            };
+
+            Compare(actual, expected);
+        }
     }
 }

--- a/Laan.SQL.Formatter.Test/TestInsertStatementFormatting.cs
+++ b/Laan.SQL.Formatter.Test/TestInsertStatementFormatting.cs
@@ -142,9 +142,7 @@ namespace Laan.Sql.Formatter.Test
             // Verify outcome
             var expected = new[]
             {
-               "INSERT INTO Product (",
-               "    Name, Price, ExpiryDate, Aisle, Shelf",
-               "    )",
+               "INSERT INTO Product (Name, Price, ExpiryDate, Aisle, Shelf)",
                "     VALUES ('Bread', 1.29, NULL, NULL, NULL)",
             };
 

--- a/Laan.SQL.Formatter/StatementFormatters/InsertStatementFormatter.cs
+++ b/Laan.SQL.Formatter/StatementFormatters/InsertStatementFormatter.cs
@@ -46,20 +46,17 @@ namespace Laan.Sql.Formatter
             {
                 string text = _statement.Columns.ToCsv();
                 List<string> lines = new List<string>();
-                if ( text.Length > WrapMarginColumn )
+                string line = "";
+                for ( int index = 0; index < _statement.Columns.Count; index++ )
                 {
-                    string line = "";
-                    for ( int index = 0; index < _statement.Columns.Count; index++ )
+                    if ( line.Length + _statement.Columns[ index ].Length >= WrapMarginColumn )
                     {
-                        if ( line.Length + _statement.Columns[ index ].Length >= WrapMarginColumn )
-                        {
-                            lines.Add( line );
-                            line = "";
-                        }
-                        line += FormatColumnWithSeparator( index );
+                        lines.Add( line );
+                        line = "";
                     }
-                    lines.Add( line );
+                    line += FormatColumnWithSeparator( index );
                 }
+                lines.Add( line );
 
                 if ( _statement.Columns.Count <= MaxOneLineColumnCount && FitsOnRow( text ) )
                     _sql.AppendFormat( " {0}\n", FormatBrackets( text ) );
@@ -70,8 +67,8 @@ namespace Laan.Sql.Formatter
 
                     using ( new IndentScope( this ) )
                     {
-                        foreach ( string line in lines )
-                            IndentAppendLine( line );
+                        foreach ( string sqlLine in lines )
+                            IndentAppendLine( sqlLine );
                         
                         IndentAppendLine( ")" );
                     }

--- a/Laan.SQL.Formatter/StatementFormatters/InsertStatementFormatter.cs
+++ b/Laan.SQL.Formatter/StatementFormatters/InsertStatementFormatter.cs
@@ -13,8 +13,8 @@ namespace Laan.Sql.Formatter
     {
         private const int MaxOneLineColumnCount = 4;
 
-        public InsertStatementFormatter( IIndentable indentable, StringBuilder sql, InsertStatement statement )
-            : base( indentable, sql, statement )
+        public InsertStatementFormatter(IIndentable indentable, StringBuilder sql, InsertStatement statement)
+            : base(indentable, sql, statement)
         {
         }
 
@@ -32,50 +32,52 @@ namespace Laan.Sql.Formatter
 
         private void FormatInsert()
         {
-            IndentAppendFormat( "{0} {1} {2}", Constants.Insert, Constants.Into, _statement.TableName );
+            IndentAppendFormat("{0} {1} {2}", Constants.Insert, Constants.Into, _statement.TableName);
         }
 
-        private string FormatColumnWithSeparator( int index )
+        private string FormatColumnWithSeparator(int index)
         {
-            return _statement.Columns[ index ] + ( index < _statement.Columns.Count - 1 ? ", " : "" );
+            return _statement.Columns[index] + (index < _statement.Columns.Count - 1 ? ", " : "");
         }
 
         private void FormatColumns()
         {
-            if ( _statement.Columns.Count > 0 )
+            if (_statement.Columns.Count == 0)
             {
-                string text = _statement.Columns.ToCsv();
-                List<string> lines = new List<string>();
-                string line = "";
-                for ( int index = 0; index < _statement.Columns.Count; index++ )
-                {
-                    if ( line.Length + _statement.Columns[ index ].Length >= WrapMarginColumn )
-                    {
-                        lines.Add( line );
-                        line = "";
-                    }
-                    line += FormatColumnWithSeparator( index );
-                }
-                lines.Add( line );
-
-                if ( _statement.Columns.Count <= MaxOneLineColumnCount && FitsOnRow( text ) )
-                    _sql.AppendFormat( " {0}\n", FormatBrackets( text ) );
-                else
-                {
-                    _sql.Append( " (" );
-                    NewLine();
-
-                    using ( new IndentScope( this ) )
-                    {
-                        foreach ( string sqlLine in lines )
-                            IndentAppendLine( sqlLine );
-                        
-                        IndentAppendLine( ")" );
-                    }
-                }
-            }
-            else
                 NewLine();
+                return;
+            }
+
+            string text = _statement.Columns.ToCsv();
+            if (FitsOnRow(text))
+            {
+                _sql.AppendFormat(" {0}\n", FormatBrackets(text));
+                return;
+            }
+
+            List<string> lines = new List<string>();
+            string line = "";
+            for (int index = 0; index < _statement.Columns.Count; index++)
+            {
+                if (line.Length + _statement.Columns[index].Length >= WrapMarginColumn)
+                {
+                    lines.Add(line);
+                    line = "";
+                }
+                line += FormatColumnWithSeparator(index);
+            }
+            lines.Add(line);
+
+            _sql.Append(" (");
+            NewLine();
+
+            using (new IndentScope(this))
+            {
+                foreach (string sqlLine in lines)
+                    IndentAppendLine(sqlLine);
+
+                IndentAppendLine(")");
+            }
         }
 
         private string GetValues(List<Expression> values)


### PR DESCRIPTION
Formatting more columns than `MaxOneLineColumnCount`, but fitting up to `WrapMarginColumn` will just skip adding the column names.

Also added test. All tests pass.