### PR TITLE
Nuget build errors and formatter for variable assignment SET statement

### DIFF
--- a/Laan.NHibernate.Appender/Laan.NHibernate.Appender.csproj
+++ b/Laan.NHibernate.Appender/Laan.NHibernate.Appender.csproj
@@ -14,6 +14,10 @@
     <ProjectReference Include="..\Laan.SQL.Parser\Laan.Sql.Parser.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="readme.md" Pack="true" PackagePath=""/>
+  </ItemGroup>
+
   <Import Project="$(SolutionDir)Build\Common.targets" />
   <Import Project="$(SolutionDir)Build\Nuget.targets" />
 </Project>

--- a/Laan.NHibernate.Appender/readme.md
+++ b/Laan.NHibernate.Appender/readme.md
@@ -1,0 +1,1 @@
+Please see [https://github.com/benlaan/sqlformat/wiki](https://github.com/benlaan/sqlformat/wiki)

--- a/Laan.Sql.Formatter/Factories/StatementFormatterFactory.cs
+++ b/Laan.Sql.Formatter/Factories/StatementFormatterFactory.cs
@@ -22,6 +22,7 @@ namespace Laan.Sql.Formatter
                 { typeof( DeleteStatement ), typeof( DeleteStatementFormatter ) },
                 { typeof( InsertStatement ), typeof( InsertStatementFormatter ) },
                 { typeof( DeclareStatement ), typeof( DeclareStatementFormatter ) },
+                { typeof( SetVariableStatement ), typeof( SetVariableStatementFormatter ) },
                 { typeof( GoTerminator ), typeof( GoTerminatorFormatter ) },
                 { typeof( IfStatement ), typeof( IfStatementFormatter ) },
                 { typeof( BeginTransactionStatement ), typeof( BeginTransactionStatementFormatter ) },

--- a/Laan.Sql.Formatter/Laan.Sql.Formatter.csproj
+++ b/Laan.Sql.Formatter/Laan.Sql.Formatter.csproj
@@ -9,6 +9,10 @@
     <ProjectReference Include="..\Laan.SQL.Parser\Laan.Sql.Parser.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="readme.md" Pack="true" PackagePath=""/>
+  </ItemGroup>
+
   <Import Project="$(SolutionDir)Build\Common.targets" />
   <Import Project="$(SolutionDir)Build\Nuget.targets" />
 

--- a/Laan.Sql.Formatter/StatementFormatters/SetVariableStatementFormatter.cs
+++ b/Laan.Sql.Formatter/StatementFormatters/SetVariableStatementFormatter.cs
@@ -1,0 +1,19 @@
+﻿using Laan.Sql.Parser.Entities;
+using System.Text;
+
+namespace Laan.Sql.Formatter
+{
+    public class SetVariableStatementFormatter : StatementFormatter<SetVariableStatement>, IStatementFormatter
+    {
+        public SetVariableStatementFormatter(IIndentable indentable, StringBuilder sql, SetVariableStatement statement)
+            : base(indentable, sql, statement)
+        {
+        }
+
+        public void Execute()
+        {
+            var formatter = new VariableAssignmentFormatter(_statement.Variable, _statement.Assignment, this, _sql);
+            formatter.Execute();
+        }
+    }
+}

--- a/Laan.Sql.Formatter/StatementFormatters/VariableAssignmentFormatter.cs
+++ b/Laan.Sql.Formatter/StatementFormatters/VariableAssignmentFormatter.cs
@@ -1,0 +1,26 @@
+﻿using Laan.Sql.Parser;
+using Laan.Sql.Parser.Expressions;
+using System.Text;
+
+namespace Laan.Sql.Formatter
+{
+    public class VariableAssignmentFormatter : BaseFormatter
+    {
+        private string _identifier;
+        private Expression _assignment;
+
+        public VariableAssignmentFormatter(string identifier, Expression assignment, IIndentable indentable, StringBuilder sql) : base(indentable, sql)
+        {
+            _identifier = identifier;
+            _assignment = assignment;
+        }
+
+        public void Execute()
+        {
+            var assignmentValue = _assignment.FormattedValue(0, this);
+            var variableAssignment = $"{Constants.Set} {_identifier} = {assignmentValue};";
+
+            IndentAppend(variableAssignment);
+        }
+    }
+}

--- a/Laan.Sql.Formatter/readme.md
+++ b/Laan.Sql.Formatter/readme.md
@@ -1,0 +1,1 @@
+Please see [https://github.com/benlaan/sqlformat/wiki](https://github.com/benlaan/sqlformat/wiki)

--- a/Laan.Sql.Parser/Laan.Sql.Parser.csproj
+++ b/Laan.Sql.Parser/Laan.Sql.Parser.csproj
@@ -12,7 +12,11 @@
     </PackageReference>
     <PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />
   </ItemGroup>
-
+  
+  <ItemGroup>
+    <None Include="readme.md" Pack="true" PackagePath=""/>
+  </ItemGroup>
+  
   <Import Project="$(SolutionDir)Build\Common.targets" />
   <Import Project="$(SolutionDir)Build\Nuget.targets" />
 

--- a/Laan.Sql.Parser/readme.md
+++ b/Laan.Sql.Parser/readme.md
@@ -1,0 +1,1 @@
+Please see [https://github.com/benlaan/sqlformat/wiki](https://github.com/benlaan/sqlformat/wiki)


### PR DESCRIPTION
Hello, thanks very much for your project!

I found that it would not build under VS2022 without adding references in 3 project files to the existing readme.md files and making sure those were not empty files:
NU5039: The readme file 'readme.md' does not exist in the package.
NU5040: The readme file 'readme.md' is empty.

I then added formatting support for the variable assignment SET statement, by copying and editing an existing example. The parser already had support for SET.

Cheers
Nick